### PR TITLE
Fix negative no-SOA ranking

### DIFF
--- a/dnsext-utils/DNS/RRCache/Types.hs
+++ b/dnsext-utils/DNS/RRCache/Types.hs
@@ -307,7 +307,9 @@ lookupEither now dom typ cls cache = lookupAlive now result dom typ cls cache
     wsoa_ ttl rank soaDom nrrs = do
         (soa, srank) <- lookupAlive now (soaResult ttl soaDom) soaDom SOA DNS.IN cache {- EMPTY hit. empty ranking and SOA result. -}
         Just (Left (soa ++ [nrr | (nrr, _) <- nrrs], srank), rank)
-    nsoa_ rank _rc = Just (Left ([], RankAdditional {- FIXME, dummy rank value for no-SOA -}), rank)
+    nsoa_ rank _rc =
+        let r = if rank > RankAdditional then RankAdditional else rank
+         in Just (Left ([], r), r)
     soaResult ettl srcDom ttl crs rank =
         Just (extractRRSet srcDom SOA DNS.IN (ettl `min` ttl {- treated as TTL of empty data -}) crs, rank)
 {- FOURMOLU_ENABLE -}

--- a/dnsext-utils/dnsext-utils.cabal
+++ b/dnsext-utils/dnsext-utils.cabal
@@ -70,6 +70,7 @@ test-suite spec
         FastStreamSpec
         ProtocolBufferSpec
         SchemaSpec
+        NegativeCacheSpec
 
     default-language:   Haskell2010
     ghc-options:        -Wall -threaded -with-rtsopts=-N

--- a/dnsext-utils/test/NegativeCacheSpec.hs
+++ b/dnsext-utils/test/NegativeCacheSpec.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+module NegativeCacheSpec where
+
+import DNS.RRCache
+import qualified DNS.Types as DNS
+import DNS.Types.Time (EpochTime)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "negative cache ranking" $
+    it "degrades rank for NoSOA results" $ do
+        let dom = DNS.fromRepresentation "example.com."
+            key = DNS.Question dom DNS.A DNS.IN
+            now = 0 :: EpochTime
+            ttl = 60
+            rank = RankAuthAnswer
+            Just cache1 = insert now key ttl (negNoSOA DNS.NoErr) rank (empty 10)
+        lookupEither now dom DNS.A DNS.IN cache1
+            `shouldBe` Just (Left ([], RankAdditional), RankAdditional)


### PR DESCRIPTION
## Summary
- compute a ranking for negative no-SOA results
- test the ranking behaviour

## Testing
- `cabal build all` *(fails: cabal not found)*